### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,9 @@
 class ItemsController < ApplicationController
   # ログインしていないユーザーは出品ページへ行けないようにする
-  before_action :authenticate_user!, only: [:new, :create]
-  before_action :set_item, only: [:show]
-
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update]
+  before_action :move_to_index, only: [:edit, :update]
+  before_action :sold_out_item, only: [:edit]
 
   # トップページ
   def index
@@ -17,9 +18,21 @@ class ItemsController < ApplicationController
   def show  
   end
 
-  #def move_to_index
-    #redirect_to root_path unless current_user.id == @item.user_id
-  #end
+  def edit
+  end
+
+  def update
+  if @item.update(item_params)
+    redirect_to item_path(@item), notice: "商品情報を更新しました"
+  else
+    render :edit, status: :unprocessable_entity
+  end
+end
+
+
+  def move_to_index
+    redirect_to root_path unless current_user.id == @item.user_id
+  end
 
   # 出品処理
   def create
@@ -31,6 +44,10 @@ class ItemsController < ApplicationController
     else
       render :new, status: :unprocessable_entity  # エラー時は出品ページに戻る
     end
+  end
+
+  def sold_out_item
+  redirect_to root_path if @item.order.present?
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,6 +19,7 @@ class ItemsController < ApplicationController
   end
 
   def edit
+  
   end
 
   def update

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,4 @@
+class Order < ApplicationRecord
+  belongs_to :item
+  belongs_to :user
+end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,0 +1,132 @@
+<%= render "shared/header" %>
+
+<%# エラーメッセージ %>
+<%= render 'shared/error_messages', model: @item %>
+
+<%= form_with model: @item, local: true do |f| %>
+
+  <%# 商品画像 %>
+  <div class="img-upload">
+    <div class="weight-bold-text">
+      商品画像
+      <span class="indispensable">必須</span>
+    </div>
+    <div class="click-upload">
+      <p>クリックしてファイルをアップロード</p>
+      <%= f.file_field :image, id:"item-image" %>
+      <% if @item.image.attached? %>
+        <p>現在の画像: <%= image_tag @item.image, class: "preview-img" %></p>
+      <% end %>
+    </div>
+  </div>
+
+  <%# 商品名と商品説明 %>
+  <div class="new-items">
+    <div class="weight-bold-text">
+      商品名
+      <span class="indispensable">必須</span>
+    </div>
+    <%= f.text_field :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+
+    <div class="items-explain">
+      <div class="weight-bold-text">
+        商品の説明
+        <span class="indispensable">必須</span>
+      </div>
+      <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）", rows:"7", maxlength:"1000" %>
+    </div>
+  </div>
+
+  <%# 商品の詳細 %>
+  <div class="items-detail">
+    <div class="weight-bold-text">商品の詳細</div>
+    <div class="form">
+      <div class="weight-bold-text">
+        カテゴリー
+        <span class="indispensable">必須</span>
+      </div>
+      <%= f.collection_select :category_id, Category.all, :id, :name, { include_blank: "選択してください" }, { class:"select-box", id:"item-category" } %>
+
+      <div class="weight-bold-text">
+        商品の状態
+        <span class="indispensable">必須</span>
+      </div>
+      <%= f.collection_select :condition_id, Condition.all, :id, :name, { include_blank: "選択してください" }, { class:"select-box", id:"item-condition" } %>
+    </div>
+  </div>
+
+  <%# 配送について %>
+  <div class="items-detail">
+    <div class="weight-bold-text question-text">
+      <span>配送について</span>
+      <a class="question" href="#">?</a>
+    </div>
+    <div class="form">
+      <div class="weight-bold-text">
+        配送料の負担
+        <span class="indispensable">必須</span>
+      </div>
+      <%= f.collection_select :shipping_fee_id, ShippingFee.all, :id, :name, { include_blank: "選択してください" }, { class:"select-box", id:"item-shipping-fee" } %>
+
+      <div class="weight-bold-text">
+        発送元の地域
+        <span class="indispensable">必須</span>
+      </div>
+      <%= f.collection_select :prefecture_id, Prefecture.all, :id, :name, { include_blank: "選択してください" }, { class:"select-box", id:"item-prefecture" } %>
+
+      <div class="weight-bold-text">
+        発送までの日数
+        <span class="indispensable">必須</span>
+      </div>
+      <%= f.collection_select :shipping_day_id, ShippingDay.all, :id, :name, { include_blank: "選択してください" }, { class:"select-box", id:"item-shipping-day" } %>
+    </div>
+  </div>
+
+  <%# 販売価格 %>
+  <div class="sell-price">
+    <div class="weight-bold-text question-text">
+      <span>販売価格<br>(¥300〜9,999,999)</span>
+      <a class="question" href="#">?</a>
+    </div>
+    <div>
+      <div class="price-content">
+        <div class="price-text">
+          <span>価格</span>
+          <span class="indispensable">必須</span>
+        </div>
+        <span class="sell-yen">¥</span>
+        <%= f.number_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+      </div>
+      <div class="price-content">
+        <span>販売手数料 (10%)</span>
+        <span><span id='add-tax-price'></span>円</span>
+      </div>
+      <div class="price-content">
+        <span>販売利益</span>
+        <span><span id='profit'></span>円</span>
+      </div>
+    </div>
+  </div>
+
+  <%# 注意書き %>
+  <div class="caution">
+    <p class="sentence">
+      <a href="#">禁止されている出品、</a>
+      <a href="#">行為</a>を必ずご確認ください。
+    </p>
+    <p class="sentence">
+      ブランド品でシリアルナンバー等がある場合はご記載ください。
+      <a href="#">偽ブランドの販売</a>は犯罪であり処罰対象です。
+    </p>
+    <p class="sentence">
+      出品をもちまして<a href="#">加盟店規約</a>に同意したことになります。
+    </p>
+  </div>
+
+  <%# 下部ボタン %>
+  <div class="sell-btn-contents">
+    <%= f.submit "変更する", class:"sell-btn" %>
+    <%= link_to 'もどる', item_path(@item), class:"back-btn" %>
+  </div>
+
+<% end %>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,132 +1,122 @@
 <%= render "shared/header" %>
 
-<%# エラーメッセージ %>
-<%= render 'shared/error_messages', model: @item %>
+<div class="items-sell-contents">
+  <header class="items-sell-header">
+    <%= link_to image_tag('furima-logo-color.png', size: '185x50'), "/" %>
+  </header>
 
-<%= form_with model: @item, local: true do |f| %>
+  <div class="items-sell-main">
+    <h2 class="items-sell-title">商品の情報を編集</h2>
 
-  <%# 商品画像 %>
-  <div class="img-upload">
-    <div class="weight-bold-text">
-      商品画像
-      <span class="indispensable">必須</span>
-    </div>
-    <div class="click-upload">
-      <p>クリックしてファイルをアップロード</p>
-      <%= f.file_field :image, id:"item-image" %>
-      <% if @item.image.attached? %>
-        <p>現在の画像: <%= image_tag @item.image, class: "preview-img" %></p>
-      <% end %>
-    </div>
-  </div>
+    <%= render 'shared/error_messages', model: @item %>
 
-  <%# 商品名と商品説明 %>
-  <div class="new-items">
-    <div class="weight-bold-text">
-      商品名
-      <span class="indispensable">必須</span>
-    </div>
-    <%= f.text_field :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+    <%= form_with model: @item, local: true do |f| %>
 
-    <div class="items-explain">
-      <div class="weight-bold-text">
-        商品の説明
-        <span class="indispensable">必須</span>
-      </div>
-      <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）", rows:"7", maxlength:"1000" %>
-    </div>
-  </div>
-
-  <%# 商品の詳細 %>
-  <div class="items-detail">
-    <div class="weight-bold-text">商品の詳細</div>
-    <div class="form">
-      <div class="weight-bold-text">
-        カテゴリー
-        <span class="indispensable">必須</span>
-      </div>
-      <%= f.collection_select :category_id, Category.all, :id, :name, { include_blank: "選択してください" }, { class:"select-box", id:"item-category" } %>
-
-      <div class="weight-bold-text">
-        商品の状態
-        <span class="indispensable">必須</span>
-      </div>
-      <%= f.collection_select :condition_id, Condition.all, :id, :name, { include_blank: "選択してください" }, { class:"select-box", id:"item-condition" } %>
-    </div>
-  </div>
-
-  <%# 配送について %>
-  <div class="items-detail">
-    <div class="weight-bold-text question-text">
-      <span>配送について</span>
-      <a class="question" href="#">?</a>
-    </div>
-    <div class="form">
-      <div class="weight-bold-text">
-        配送料の負担
-        <span class="indispensable">必須</span>
-      </div>
-      <%= f.collection_select :shipping_fee_id, ShippingFee.all, :id, :name, { include_blank: "選択してください" }, { class:"select-box", id:"item-shipping-fee" } %>
-
-      <div class="weight-bold-text">
-        発送元の地域
-        <span class="indispensable">必須</span>
-      </div>
-      <%= f.collection_select :prefecture_id, Prefecture.all, :id, :name, { include_blank: "選択してください" }, { class:"select-box", id:"item-prefecture" } %>
-
-      <div class="weight-bold-text">
-        発送までの日数
-        <span class="indispensable">必須</span>
-      </div>
-      <%= f.collection_select :shipping_day_id, ShippingDay.all, :id, :name, { include_blank: "選択してください" }, { class:"select-box", id:"item-shipping-day" } %>
-    </div>
-  </div>
-
-  <%# 販売価格 %>
-  <div class="sell-price">
-    <div class="weight-bold-text question-text">
-      <span>販売価格<br>(¥300〜9,999,999)</span>
-      <a class="question" href="#">?</a>
-    </div>
-    <div>
-      <div class="price-content">
-        <div class="price-text">
-          <span>価格</span>
+      <!-- 商品画像 -->
+      <div class="img-upload">
+        <div class="weight-bold-text">
+          商品画像
           <span class="indispensable">必須</span>
         </div>
-        <span class="sell-yen">¥</span>
-        <%= f.number_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+        <div class="click-upload">
+          <p>クリックしてファイルをアップロード</p>
+          <%= f.file_field :image, id:"item-image" %>
+
+          <% if @item.image.attached? %>
+            <p>現在の画像：</p>
+            <%= image_tag @item.image, class: "preview-img" %>
+          <% end %>
+        </div>
       </div>
-      <div class="price-content">
-        <span>販売手数料 (10%)</span>
-        <span><span id='add-tax-price'></span>円</span>
+
+      <!-- 商品名 -->
+      <div class="new-items">
+        <div class="weight-bold-text">
+          商品名
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :name, class:"items-text", placeholder:"商品名（必須40文字まで）" %>
+
+        <div class="items-explain">
+          <div class="weight-bold-text">
+            商品の説明
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.text_area :description, class:"items-text", rows:"7", placeholder:"商品の説明（必須1,000文字まで）" %>
+        </div>
       </div>
-      <div class="price-content">
-        <span>販売利益</span>
-        <span><span id='profit'></span>円</span>
+
+      <!-- 商品の詳細 -->
+      <div class="items-detail">
+        <div class="weight-bold-text">商品の詳細</div>
+
+        <div class="form">
+          <div class="weight-bold-text">
+            カテゴリー
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select :category_id, Category.all, :id, :name,
+                { include_blank: "選択してください" },
+                { class:"select-box" } %>
+
+          <div class="weight-bold-text">
+            商品の状態
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select :condition_id, Condition.all, :id, :name,
+                { include_blank: "選択してください" },
+                { class:"select-box" } %>
+        </div>
       </div>
-    </div>
+
+      <!-- 配送 -->
+      <div class="items-detail">
+        <div class="weight-bold-text">配送について</div>
+        <div class="form">
+          <div class="weight-bold-text">
+            配送料の負担
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select :shipping_fee_id, ShippingFee.all, :id, :name,
+                { include_blank: "選択してください" },
+                { class:"select-box" } %>
+
+          <div class="weight-bold-text">
+            発送元の地域
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select :prefecture_id, Prefecture.all, :id, :name,
+                { include_blank: "選択してください" },
+                { class:"select-box" } %>
+
+          <div class="weight-bold-text">
+            発送までの日数
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select :shipping_day_id, ShippingDay.all, :id, :name,
+                { include_blank: "選択してください" },
+                { class:"select-box" } %>
+        </div>
+      </div>
+
+      <!-- 金額 -->
+      <div class="sell-price">
+        <div class="price-content">
+          <span class="weight-bold-text">価格</span>
+          <%= f.number_field :price, class:"price-input", placeholder:"例）300" %>
+        </div>
+      </div>
+
+      <!-- ボタン -->
+      <div class="sell-btn-contents">
+        <%= f.submit "変更する", class:"sell-btn" %>
+        <%= link_to "もどる", item_path(@item), class:"back-btn" %>
+      </div>
+
+    <% end %>
   </div>
 
-  <%# 注意書き %>
-  <div class="caution">
-    <p class="sentence">
-      <a href="#">禁止されている出品、</a>
-      <a href="#">行為</a>を必ずご確認ください。
-    </p>
-    <p class="sentence">
-      ブランド品でシリアルナンバー等がある場合はご記載ください。
-      <a href="#">偽ブランドの販売</a>は犯罪であり処罰対象です。
-    </p>
-    <p class="sentence">
-      出品をもちまして<a href="#">加盟店規約</a>に同意したことになります。
-    </p>
-  </div>
-
-  <%# 下部ボタン %>
-  <div class="sell-btn-contents">
-    <%= f.submit "変更する", class:"sell-btn" %>
-    <%= link_to 'もどる', item_path(@item), class:"back-btn" %>
-  </div>
-
-<% end %>
+  <footer class="items-sell-footer">
+    <%= link_to image_tag('furima-logo-color.png', size: '185x50'), "/" %>
+  </footer>
+</div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,10 +27,10 @@
     </div>
 
 
-    <% if user_signed_in? && @item.order.blank? %>
+    <% if user_signed_in?  %>
       <% if current_user.id == @item.user_id %>
     
-        <%= link_to "商品の編集", "#", class: "item-red-btn" %>
+        <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", data: { turbo_method: :delete }, class: "item-destroy" %>
       <% else %>    

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,6 @@ Rails.application.routes.draw do
 
   devise_for :users
   
- resources :items, only: [:index, :show, :new, :create]
+ resources :items, only: [:index, :show, :new, :create, :edit, :update]
+
 end


### PR DESCRIPTION
What

１．商品情報編集ページ（editアクション・edit.html.erb）を実装しました。
　商品出品時と同じレイアウト・フォーム構成で編集できるようにしました。
　既存の商品情報がフォームに自動で入力されるようにしています（画像・販売手数料・利益は非表示のまま）。
２．商品情報の更新機能（updateアクション）を実装しました。
　正常に更新できた場合は詳細ページへリダイレクトします。
　バリデーションエラーが発生した場合は edit ページへ戻し、エラーメッセージを表示します。
３．ログイン状態および権限に基づくアクセス制御を追加しました。
　未ログインユーザーは編集ページへアクセスできず、ログインページへ遷移します。
　出品者以外のユーザーが編集ページにアクセスした場合はトップページへ遷移します。
　売却済商品の編集ページに出品者がアクセスした場合もトップページへ遷移します。
４．ビューボタンの制御を実装しました。
　商品詳細画面にて、出品者へ「編集」「削除」ボタンを表示。
　出品者以外のユーザーには「購入」ボタンを表示。
　編集機能のみの実装のため、削除・購入ボタンはリンク先未設定。
Why
１．出品した商品の内容を後から編集できるようにするため。
　ユーザーが価格・説明などを後から変更できることは、フリマアプリとして必須の機能のため。
２．ユーザー体験を統一するため、出品ページと同一のフォームUIを採用。
　編集と出品が同じ見た目になることで、ユーザーが違和感なく操作できる。
３．誤ったユーザーが編集できないようにするためのアクセス制御が必要なため。
　未ログイン、他ユーザー、売却済みなどの条件でアクセス制限することで、不正な編集を防ぎます。
４．エラーハンドリングにより、ユーザーが入力した内容を保持しつつ再編集できるようにするため。
　編集失敗時に入力内容が消えると UX が悪いため、フォーム値が残る設計にしています。
５．商品詳細ページから適切に編集画面へ遷移できるようにするため。
　編集ボタンの表示制御により、出品者だけが編集できる仕様を満たしています。

ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/4d88ee9e71ca44dcc734e0ee8074ae7b
必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/c69870184e52e6f79e9a97eba094f2b4
入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/efab6baee89c02536f5ad5224abe95cd
何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/24faef2181a90de664329b858a80c2f5
ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/200159309d0d08f8134d53eb6275bbee
ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/2e4eb4f8026446d3126cada6adb96378
商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/521ac911c389893b6dbfe09eeb6ed256