### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -48,7 +48,6 @@ end
   end
 
   def destroy
-  @item = Item.find(params[:id])
 
   if current_user.id == @item.user_id
     @item.destroy

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -48,10 +48,16 @@ end
   end
 
   def destroy
-  @item.destroy
-  redirect_to root_path
+  @item = Item.find(params[:id])
+
+  if current_user.id == @item.user_id
+    @item.destroy
+    redirect_to root_path, notice: "商品を削除しました"
+  else
+    redirect_to root_path, alert: "削除権限がありません"
   end
-  
+end
+
   def sold_out_item
   redirect_to root_path if @item.order.present?
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,8 @@
 class ItemsController < ApplicationController
   # ログインしていないユーザーは出品ページへ行けないようにする
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :set_item, only: [:show, :edit, :update]
-  before_action :move_to_index, only: [:edit, :update]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :move_to_index_unless_seller, only: [:edit, :update]
   before_action :sold_out_item, only: [:edit]
 
   # トップページ
@@ -47,6 +47,11 @@ end
     end
   end
 
+  def destroy
+  @item.destroy
+  redirect_to root_path
+  end
+  
   def sold_out_item
   redirect_to root_path if @item.order.present?
   end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,19 +27,24 @@
     </div>
 
 
-    <% if user_signed_in?  %>
-      <% if current_user.id == @item.user_id %>
-    
-        <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
-        <p class="or-text">or</p>
-      <% if user_signed_in? && current_user.id == @item.user_id && @item.order.blank? %>  
-        <%= link_to "削除",  item_path(@item), data: { turbo_method: :delete }, class: "item-destroy" %>
-      <% end %>
-      
-      <% else %>    
-      <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
-      <% end %>
+  <% if user_signed_in? %>
+  <% if current_user.id == @item.user_id %>
+
+    <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
+    <p class="or-text">or</p>
+
+    <% if @item.order.blank? %>
+    <%= link_to "削除", item_path(@item),
+    data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
+    class: "item-destroy" %>
+
     <% end %>
+
+  <% else %>
+    <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
+  <% end %>
+<% end %>
+
 
 
     <div class="item-explain-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -32,7 +32,10 @@
     
         <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", data: { turbo_method: :delete }, class: "item-destroy" %>
+      <% if user_signed_in? && current_user.id == @item.user_id && @item.order.blank? %>  
+        <%= link_to "削除",  item_path(@item), data: { turbo_method: :delete }, class: "item-destroy" %>
+      <% end %>
+      
       <% else %>    
       <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
       <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,9 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
     <%= javascript_importmap_tags %>
+
   </head>
 
   <body>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,6 @@ Rails.application.routes.draw do
 
   devise_for :users
   
- resources :items, only: [:index, :show, :new, :create, :edit, :update]
+ resources :items, only: [:index, :show, :new, :create, :edit, :update, :destroy]
 
 end


### PR DESCRIPTION
## What

商品詳細ページに削除ボタンを表示し、ログイン中かつ自身が出品した商品のみ削除できるようにしました。

削除ボタンは Turbo に対応した data: { turbo_method: :delete } を使用し、クリックで destroy アクションへ遷移するように実装しました。

削除後はトップページ（root_path）へリダイレクトするように設定しています。

## Why

Rails 7 / Turbo 環境では method: :delete が動作しないため、data-turbo-method を利用して確実に削除リクエストを送れるようにしています。

不正な商品削除防止のため、current_user.id == @item.user_id による本人チェックを行い、安全性を確保しています。

削除完了後にトップページへ戻すことで、ユーザーがスムーズに操作を続けられる UX を実現しています。

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/e5975d3bcb126dd1c25ebba70f7fc5f2